### PR TITLE
Specific uid and gid for slurm system user

### DIFF
--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -1083,9 +1083,13 @@ mkdir -p $RPM_BUILD_ROOT/%{_docdir}
 #    fi
 #fi
 
-getent passwd slurm >/dev/null || \
-    /usr/sbin/useradd -U -c "SLURM resource manager" \
-    -s /sbin/nologin -r -d %{_sysconfdir} slurm
+# provide specific uid/gid to ensure that it is the same across the cluster
+/usr/bin/getent group slurm >/dev/null 2>&1 || \
+  /usr/sbin/groupadd -r slurm -g 201
+/usr/bin/getent passwd slurm >/dev/null 2>&1 || \
+  /usr/sbin/useradd -c "SLURM resource manager" \
+  -d %{_sysconfdir} -g slurm -s /bin/nologin -r slurm -u 201
+  
 exit 0
 
 %post


### PR DESCRIPTION
Slurm requires that uid/gid are the same across the cluster, this patch follows the example of munge spec file (which uses uid/gid 200) and sets uid and gid to 201.

Differing ids are a problem for stateful xCAT install, where ids end up being different - stateful xCAT image installs different packages than default install on the SMS.
 Regardless, given that this is a requirement ( https://slurm.schedmd.com/accounting.html) it is a good practice to enforce this.